### PR TITLE
Fix mcp2210_spi_transfer() start offset of the data.

### DIFF
--- a/mcp2210.c
+++ b/mcp2210.c
@@ -223,7 +223,7 @@ mcp2210_spi_transfer (int fd, mcp2210_packet spi_packet, char *data, short len)
 
 retry:
 		packet[1] = wr_len;
-		memcpy (&packet[2], &data[wr], wr_len);
+		memcpy (&packet[4], &data[wr], wr_len);
 		ret = mcp2210_command (fd, packet, MCP2210_SPI_TRANSFER);
 
 		nanosleep (&delay, NULL);


### PR DESCRIPTION
Hi Lubomir ,


First, thanks for the nice implementation !

-----

This PR fix the `mcp2210_spi_transfer()` **broken routine**:

  - According to the [datasheet](https://www.microchip.com/content/dam/mchp/documents/OTH/ProductDocuments/DataSheets/MCP2210-Data-Sheet-20002288B.pdf) data payload **should begin at 0x04** (not 0x02):
```
3.5.1 TRANSFER SPI DATA

TABLE 3-58: COMMAND STRUCTURE
Byte | Index Meaning
    0 0x42 – Transfer SPI Data – command code
    1 The number of bytes to be transferred in this packet (from 0 to 60 inclusively)
    2 0x00 – Reserved
    3 0x00 – Reserved
    4-63 The SPI Data to be sent on the data transfer
```
- A test program I was using (on some custom [USB LoRA](https://github.com/cbalint13/usb-evp)) to validate transfers:
```
#include <errno.h>
#include <stdio.h>
#include <fcntl.h>
#include <stdlib.h>

#include "mcp2210.h"


int main()
{

  int fd;
  int ret,err,cnt;

  mcp2210_packet packet = { 0, };

  fd = open("/dev/hidraw3", O_RDWR);

  ret = mcp2210_command(fd, packet, MCP2210_SPI_GET);
  if( ret < 0)
  {
    fprintf (stderr, "Trouble: %s\n", mcp2210_strerror (err));
    close(fd);
    return -1;
  }

  cnt =  mcp2210_gp6_count_get(fd, packet, 0);
  printf("MSG count: %i\n", cnt);

  mcp2210_gpio_set_pin(packet, 7, 1);
  ret = mcp2210_command(fd, packet, MCP2210_GPIO_VAL_SET);

  u_int8_t data[2] = { 0x42, 0xFF };
  ret = mcp2210_spi_transfer(fd, packet, data, 2);
  printf("RX data: %02x\n", data[1]);

  mcp2210_gpio_set_pin(packet, 7, 0);
  ret = mcp2210_command(fd, packet, MCP2210_GPIO_VAL_SET);


  close(fd);

  return 0;

}
```

Thank You @lkundrak !
~cristian.

